### PR TITLE
Increase payload size limit to resolve 413 errors and stabilize test suite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 DATABASE_URL=postgres://postgres:password@127.0.0.1:5432/gemini_api_proxy
 TEST_DATABASE_URL=postgres://postgres:password@127.0.0.1:5432/test_gemini_api_proxy
 GEMINI_BASE_URL=https://generativelanguage.googleapis.com
-PAYLOAD_SIZE_LIMIT=10485760 # Payload size limit in bytes. Defaults to 10MB (10 * 1024 * 1024 = 10485760)
+# Payload size limit in bytes. Defaults to 10MB (10 * 1024 * 1024 = 10485760)
+PAYLOAD_SIZE_LIMIT=10485760
 

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 DATABASE_URL=postgres://postgres:password@127.0.0.1:5432/gemini_api_proxy
 TEST_DATABASE_URL=postgres://postgres:password@127.0.0.1:5432/test_gemini_api_proxy
 GEMINI_BASE_URL=https://generativelanguage.googleapis.com
+PAYLOAD_SIZE_LIMIT=10485760 # Payload size limit in bytes. Defaults to 10MB (10 * 1024 * 1024 = 10485760)
+

--- a/.sqlx/query-5a717d5fd7ab4e4bbe6aa2cb10ab27a8d6d7f1f6a4c777b6ac4e5f4ca6570158.json
+++ b/.sqlx/query-5a717d5fd7ab4e4bbe6aa2cb10ab27a8d6d7f1f6a4c777b6ac4e5f4ca6570158.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, hashed_key, is_active, created_at FROM api_keys WHERE hashed_key = $1",
+  "query": "SELECT id, hashed_key, is_active, created_at, name FROM api_keys WHERE hashed_key = $1",
   "describe": {
     "columns": [
       {
@@ -22,6 +22,11 @@
         "ordinal": 3,
         "name": "created_at",
         "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
@@ -33,8 +38,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "5779ed228276eb91c9d381156d4fd764c965b3f3716a1e964e556b927fc6c3a7"
+  "hash": "5a717d5fd7ab4e4bbe6aa2cb10ab27a8d6d7f1f6a4c777b6ac4e5f4ca6570158"
 }

--- a/.sqlx/query-ff3e785443e65f8b8096e6d44ac63eb9555eb2aa0da8c00170eb8c42c80ad7f1.json
+++ b/.sqlx/query-ff3e785443e65f8b8096e6d44ac63eb9555eb2aa0da8c00170eb8c42c80ad7f1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO api_keys (hashed_key, is_active)\n            VALUES ($1, $2)\n            RETURNING id, hashed_key, is_active, created_at\n            ",
+  "query": "\n            INSERT INTO api_keys (hashed_key, is_active, name)\n            VALUES ($1, $2, $3)\n            RETURNING id, hashed_key, is_active, created_at, name\n            ",
   "describe": {
     "columns": [
       {
@@ -22,20 +22,27 @@
         "ordinal": 3,
         "name": "created_at",
         "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
       "Left": [
         "Text",
-        "Bool"
+        "Bool",
+        "Varchar"
       ]
     },
     "nullable": [
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "883719e63396f5dd0a269a746f4566c570019b021b75fc24ddc8e940682e5f08"
+  "hash": "ff3e785443e65f8b8096e6d44ac63eb9555eb2aa0da8c00170eb8c42c80ad7f1"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,7 @@ dependencies = [
 name = "gemini_api_proxy"
 version = "0.1.0"
 dependencies = [
+ "actix-http",
  "actix-web",
  "chrono",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 uuid = { version = "1.20.0", features = ["v4"] }
 
 [dev-dependencies]
+actix-http = "3"
 wiremock = "0.6.5"

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 #[derive(Clone)]
 pub struct Config {
     pub database_url: String,
-    pub test_database_url: String,
+    pub test_database_url: Option<String>,
     pub gemini_base_url: String,
     pub payload_size_limit: usize,
 }
@@ -15,11 +15,13 @@ impl Config {
     pub fn from_env() -> Result<Self, Box<dyn Error + Send + Sync>> {
         Ok(Self {
             database_url: env::var("DATABASE_URL")?,
-            test_database_url: env::var("TEST_DATABASE_URL")?,
-            gemini_base_url: env::var("GEMINI_BASE_URL")?,
+            test_database_url: env::var("TEST_DATABASE_URL").ok(),
+            gemini_base_url: env::var("GEMINI_BASE_URL")
+                .unwrap_or_else(|_| "https://generativelanguage.googleapis.com".to_string()),
             payload_size_limit: env::var("PAYLOAD_SIZE_LIMIT")
-                .unwrap_or_else(|_| "10485760".to_string())
-                .parse()?,
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(10485760), // Default to 10MB
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,28 @@
 use sqlx::{PgPool, postgres::PgPoolOptions};
+use std::env;
 use std::error::Error;
 use std::time::Duration;
+
+#[derive(Clone)]
+pub struct Config {
+    pub database_url: String,
+    pub test_database_url: String,
+    pub gemini_base_url: String,
+    pub payload_size_limit: usize,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, Box<dyn Error + Send + Sync>> {
+        Ok(Self {
+            database_url: env::var("DATABASE_URL")?,
+            test_database_url: env::var("TEST_DATABASE_URL")?,
+            gemini_base_url: env::var("GEMINI_BASE_URL")?,
+            payload_size_limit: env::var("PAYLOAD_SIZE_LIMIT")
+                .unwrap_or_else(|_| "10485760".to_string())
+                .parse()?,
+        })
+    }
+}
 
 pub async fn get_db_pool(
     env_key_override: Option<&str>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ pub async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let app_config = config.clone();
 
     // 2. Create and get the database connection pool.
-    let pool = config::get_db_pool(Some(&config.database_url)).await?;
+    let pool = config::get_db_pool(None).await?;
     info!("Database connection pool created.");
 
     // 3. Run database migrations

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,26 @@
-use actix_web::{App, HttpServer, web};
+use actix_web::{web, App, HttpServer};
 use gemini_api_proxy::{
-    config,
+    config::{self, Config},
     middleware::auth::ApiKeyAuth,
     routes::{health, proxy},
 };
 use log::{info, warn};
-use std::env;
 use std::error::Error;
 
 /// Entry point for the Actix Web application.
 #[actix_web::main]
 pub async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    // 1. Initialize the logger for structured and colorful logging.
+    // 1. Initialize the logger and load environment variables.
     env_logger::init();
     dotenvy::dotenv().ok();
     info!("Server startup initiated.");
 
+    // Load configuration
+    let config = Config::from_env()?;
+    let app_config = config.clone();
+
     // 2. Create and get the database connection pool.
-    let pool = config::get_db_pool(None).await?;
+    let pool = config::get_db_pool(Some(&config.database_url)).await?;
     info!("Database connection pool created.");
 
     // 3. Run database migrations
@@ -33,17 +36,17 @@ pub async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // 5. Initialize shared HTTP client
     let client = reqwest::Client::new();
-    let gemini_base_url = env::var("GEMINI_BASE_URL")
-        .unwrap_or_else(|_| "https://generativelanguage.googleapis.com".to_string());
 
-    info!("Gemini Base URL: {}", gemini_base_url);
+    info!("Gemini Base URL: {}", &config.gemini_base_url);
+    info!("Payload size limit: {} bytes", &config.payload_size_limit);
 
     // 6. Configure and start the Actix Web server.
     HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(client.clone()))
-            .app_data(web::Data::new(gemini_base_url.clone()))
+            .app_data(web::Data::new(app_config.clone()))
+            .app_data(web::JsonConfig::default().limit(app_config.payload_size_limit))
             .service(web::resource("/health").route(web::get().to(health::health_check)))
             .service(
                 web::scope("/v1beta")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use actix_web::{web, App, HttpServer};
+use actix_web::{App, HttpServer, web};
 use gemini_api_proxy::{
     config::{self, Config},
     middleware::auth::ApiKeyAuth,
@@ -47,6 +47,7 @@ pub async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             .app_data(web::Data::new(client.clone()))
             .app_data(web::Data::new(app_config.clone()))
             .app_data(web::JsonConfig::default().limit(app_config.payload_size_limit))
+            .app_data(web::PayloadConfig::default().limit(app_config.payload_size_limit))
             .service(web::resource("/health").route(web::get().to(health::health_check)))
             .service(
                 web::scope("/v1beta")

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -63,7 +63,10 @@ where
                 .and_then(|hv| hv.to_str().ok());
 
             let api_key = match api_key {
-                Some(key) => key,
+                Some(key) => {
+                    info!("API Key received.");
+                    key
+                }
                 None => {
                     info!("API Key missing, returning 401 Unauthorized");
                     let (req, _pl) = req.into_parts();
@@ -74,8 +77,12 @@ where
 
             let pool = req.app_data::<Data<PgPool>>();
             let pool = match pool {
-                Some(pool) => pool,
+                Some(pool) => {
+                    info!("Database pool found in app data.");
+                    pool
+                }
                 None => {
+                    info!("Database pool not found in app data, returning 500 Internal Server Error");
                     let (req, _pl) = req.into_parts();
                     let res = HttpResponse::InternalServerError()
                         .body("Database pool not found in app data")
@@ -85,17 +92,24 @@ where
             };
 
             let hashed_api_key = hash_api_key(api_key);
+            info!("Hashed API Key: {}", hashed_api_key);
 
             let result = ApiKey::find_by_hashed_key(pool.get_ref(), &hashed_api_key).await;
 
             match result {
                 Ok(Some(key)) if key.is_active => {
-                    info!("API Key valid, forwarding request");
+                    info!("API Key valid and active, forwarding request");
                     req.extensions_mut().insert(key.id);
                     s_cloned.call(req).await.map(|res| res.map_into_left_body())
                 }
-                Ok(_) => {
-                    info!("API Key invalid or inactive, returning 403 Forbidden");
+                Ok(Some(_)) => {
+                    info!("API Key inactive, returning 403 Forbidden");
+                    let (req, _pl) = req.into_parts();
+                    let res = HttpResponse::Forbidden().finish().map_into_right_body();
+                    Ok(ServiceResponse::new(req, res))
+                }
+                Ok(None) => {
+                    info!("API Key not found, returning 403 Forbidden");
                     let (req, _pl) = req.into_parts();
                     let res = HttpResponse::Forbidden().finish().map_into_right_body();
                     Ok(ServiceResponse::new(req, res))

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -92,10 +92,8 @@ where
             };
 
             let hashed_api_key = hash_api_key(api_key);
-            info!("Hashed API Key: {}", hashed_api_key);
 
             let result = ApiKey::find_by_hashed_key(pool.get_ref(), &hashed_api_key).await;
-
             match result {
                 Ok(Some(key)) if key.is_active => {
                     info!("API Key valid and active, forwarding request");

--- a/src/models/api_key.rs
+++ b/src/models/api_key.rs
@@ -8,29 +8,31 @@ pub struct ApiKey {
     pub hashed_key: String,
     pub is_active: bool,
     pub created_at: NaiveDateTime,
+    pub name: String,
 }
 
 impl ApiKey {
     pub async fn find_by_hashed_key(pool: &PgPool, hashed_key: &str) -> Result<Option<Self>> {
         sqlx::query_as!(
             ApiKey,
-            "SELECT id, hashed_key, is_active, created_at FROM api_keys WHERE hashed_key = $1",
+            "SELECT id, hashed_key, is_active, created_at, name FROM api_keys WHERE hashed_key = $1",
             hashed_key
         )
         .fetch_optional(pool)
         .await
     }
 
-    pub async fn create(pool: &PgPool, hashed_key: &str, is_active: bool) -> Result<Self> {
+    pub async fn create(pool: &PgPool, hashed_key: &str, is_active: bool, name: &str) -> Result<Self> {
         sqlx::query_as!(
             ApiKey,
             r#"
-            INSERT INTO api_keys (hashed_key, is_active)
-            VALUES ($1, $2)
-            RETURNING id, hashed_key, is_active, created_at
+            INSERT INTO api_keys (hashed_key, is_active, name)
+            VALUES ($1, $2, $3)
+            RETURNING id, hashed_key, is_active, created_at, name
             "#,
             hashed_key,
-            is_active
+            is_active,
+            name
         )
         .fetch_one(pool)
         .await

--- a/src/routes/proxy.rs
+++ b/src/routes/proxy.rs
@@ -37,7 +37,7 @@ pub async fn proxy_handler(
     req: HttpRequest,
     body: Bytes,
     client: web::Data<reqwest::Client>,
-    base_url: web::Data<String>,
+    config: web::Data<crate::config::Config>,
     pool: web::Data<PgPool>,
 ) -> HttpResponse {
     let start = Instant::now();
@@ -49,7 +49,7 @@ pub async fn proxy_handler(
         .unwrap_or_else(|| req.path().trim_start_matches("/v1beta/"));
     let endpoint = tail.to_string();
 
-    let base = base_url.as_str().trim_end_matches('/');
+    let base = config.gemini_base_url.trim_end_matches('/');
     let mut upstream_url = format!("{}/v1beta/{}", base, tail);
     if let Some(query) = req.uri().query() {
         upstream_url.push('?');

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -1,30 +1,48 @@
-use actix_web::{App, HttpResponse, test, web};
+use actix_http::Request;
+use actix_web::{
+    dev::{Service, ServiceResponse},
+    http::StatusCode,
+    test, App, Error, HttpResponse, web,
+};
 use gemini_api_proxy::middleware::auth::ApiKeyAuth;
+use sqlx::PgPool;
+use uuid::Uuid;
+
 mod common;
 
 const INVALID_API_KEY: &str = "INVALID_KEY";
-
 async fn dummy_handler() -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-#[actix_web::test]
-async fn valid_api_key_returns_200_ok() {
+async fn setup_app() -> (
+    impl Service<Request, Response = ServiceResponse, Error = Error>,
+    PgPool,
+) {
     let pool = common::configure_test_db().await;
-    common::seed_api_key(&pool).await;
-
+    let mock_config = common::setup_test_config("http://localhost".to_string());
     let app = test::init_service(
-        App::new().app_data(web::Data::new(pool.clone())).service(
-            web::resource("/v1beta/test")
-                .wrap(ApiKeyAuth)
-                .route(web::get().to(dummy_handler)),
-        ),
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            .app_data(web::Data::new(mock_config))
+            .service(
+                web::resource("/v1beta/test")
+                    .wrap(ApiKeyAuth)
+                    .route(web::get().to(dummy_handler)),
+            ),
     )
     .await;
+    (app, pool)
+}
+
+#[actix_web::test]
+async fn valid_api_key_returns_200_ok() {
+    let (app, pool) = setup_app().await;
+    let api_key = common::seed_unique_api_key(&pool, &Uuid::new_v4().to_string()).await;
 
     let req = test::TestRequest::get()
         .uri("/v1beta/test")
-        .insert_header(("x-goog-api-key", common::VALID_API_KEY))
+        .insert_header(("x-goog-api-key", api_key.as_str()))
         .to_request();
     let resp = test::call_service(&app, req).await;
 
@@ -33,16 +51,7 @@ async fn valid_api_key_returns_200_ok() {
 
 #[actix_web::test]
 async fn invalid_api_key_returns_403_forbidden() {
-    let pool = common::configure_test_db().await;
-
-    let app = test::init_service(
-        App::new().app_data(web::Data::new(pool.clone())).service(
-            web::resource("/v1beta/test")
-                .wrap(ApiKeyAuth)
-                .route(web::get().to(dummy_handler)),
-        ),
-    )
-    .await;
+    let (app, _) = setup_app().await;
 
     let req = test::TestRequest::get()
         .uri("/v1beta/test")
@@ -50,24 +59,15 @@ async fn invalid_api_key_returns_403_forbidden() {
         .to_request();
     let resp = test::call_service(&app, req).await;
 
-    assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 #[actix_web::test]
 async fn missing_api_key_returns_401_unauthorized() {
-    let pool = common::configure_test_db().await;
-
-    let app = test::init_service(
-        App::new().app_data(web::Data::new(pool.clone())).service(
-            web::resource("/v1beta/test")
-                .wrap(ApiKeyAuth)
-                .route(web::get().to(dummy_handler)),
-        ),
-    )
-    .await;
+    let (app, _) = setup_app().await;
 
     let req = test::TestRequest::get().uri("/v1beta/test").to_request();
     let resp = test::call_service(&app, req).await;
 
-    assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,6 @@
 #![allow(dead_code)]
 
-use dotenvy;
-use env_logger;
-use gemini_api_proxy::{config, models::api_key::ApiKey};
+use gemini_api_proxy::{config, models::api_key::ApiKey, utils::crypto::hash_api_key};
 use sqlx::PgPool;
 use std::sync::Once;
 use std::time::Duration;
@@ -21,8 +19,20 @@ pub fn setup() {
 }
 
 // Helper to seed the database with a valid API key for testing
-pub async fn seed_api_key(pool: &PgPool) {
-    let _ = ApiKey::create(pool, VALID_API_KEY_HASH, true).await;
+pub async fn seed_api_key(pool: &PgPool, unique_name: &str) {
+    let _ = ApiKey::create(pool, VALID_API_KEY_HASH, true, unique_name)
+        .await
+        .expect("Failed to create API key for test");
+}
+
+// Helper to seed a unique API key and return it
+pub async fn seed_unique_api_key(pool: &PgPool, unique_name: &str) -> String {
+    let api_key = format!("KEY_{}", uuid::Uuid::new_v4());
+    let hashed_key = hash_api_key(&api_key);
+    let _ = ApiKey::create(pool, &hashed_key, true, unique_name)
+        .await
+        .expect("Failed to create unique API key for test");
+    api_key
 }
 
 /// Helper to configure the test database and return a connection pool
@@ -44,6 +54,16 @@ pub async fn configure_test_db() -> PgPool {
         .expect("Failed to truncate tables");
 
     pool
+}
+
+// Helper to create a Config for tests
+pub fn setup_test_config(gemini_base_url: String) -> config::Config {
+    config::Config {
+        database_url: "".to_string(),
+        test_database_url: "".to_string(),
+        gemini_base_url,
+        payload_size_limit: 1024, // Set a default for testing
+    }
 }
 
 // Helper to poll for request logs to appear in the database

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -60,7 +60,7 @@ pub async fn configure_test_db() -> PgPool {
 pub fn setup_test_config(gemini_base_url: String) -> config::Config {
     config::Config {
         database_url: "".to_string(),
-        test_database_url: "".to_string(),
+        test_database_url: Some("".to_string()),
         gemini_base_url,
         payload_size_limit: 1024, // Set a default for testing
     }

--- a/tests/logging_test.rs
+++ b/tests/logging_test.rs
@@ -1,5 +1,6 @@
 use actix_web::{App, test, web};
 use gemini_api_proxy::{middleware::auth::ApiKeyAuth, routes::proxy};
+use uuid::Uuid;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 mod common;
@@ -8,7 +9,7 @@ mod common;
 async fn test_request_logging() {
     // 1. Setup
     let pool = common::configure_test_db().await;
-    common::seed_api_key(&pool).await;
+    let api_key = common::seed_unique_api_key(&pool, &Uuid::new_v4().to_string()).await;
 
     let mock_server = MockServer::start().await;
     let gemini_base_url = mock_server.uri();
@@ -27,12 +28,13 @@ async fn test_request_logging() {
         .await;
 
     let client = reqwest::Client::new();
+    let mock_config = common::setup_test_config(gemini_base_url);
 
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(client))
-            .app_data(web::Data::new(gemini_base_url))
+            .app_data(web::Data::new(mock_config))
             .service(
                 web::scope("/v1beta")
                     .wrap(ApiKeyAuth)
@@ -44,7 +46,7 @@ async fn test_request_logging() {
     // 2. Act
     let req = test::TestRequest::post()
         .uri("/v1beta/models/gemini-pro:generateContent")
-        .insert_header(("x-goog-api-key", common::VALID_API_KEY))
+        .insert_header(("x-goog-api-key", api_key.as_str()))
         .set_json(serde_json::json!({}))
         .to_request();
 

--- a/tests/proxy_test.rs
+++ b/tests/proxy_test.rs
@@ -1,22 +1,49 @@
-use actix_web::{App, test, web};
+use actix_http::Request;
+use actix_web::{
+    dev::{Service, ServiceResponse},
+    test, App, Error, web,
+};
 use gemini_api_proxy::{middleware::auth::ApiKeyAuth, routes::proxy};
+use uuid::Uuid;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
 mod common;
+
+async fn setup_app(
+    unique_name: &str,
+) -> (
+    impl Service<Request, Response = ServiceResponse, Error = Error>,
+    MockServer,
+    String,
+) {
+    let pool = common::configure_test_db().await;
+    let api_key = common::seed_unique_api_key(&pool, unique_name).await;
+    let mock_server = MockServer::start().await;
+    let mock_config = common::setup_test_config(mock_server.uri());
+    let client = reqwest::Client::new();
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            .app_data(web::Data::new(client))
+            .app_data(web::Data::new(mock_config))
+            .service(
+                web::scope("/v1beta")
+                    .wrap(ApiKeyAuth)
+                    .route("/{tail:.*}", web::to(proxy::proxy_handler)),
+            ),
+    )
+    .await;
+    (app, mock_server, api_key)
+}
 
 #[actix_web::test]
 async fn test_proxy_request_forwarding() {
-    // 1. Setup Test DB and Seed Key
-    let pool = common::configure_test_db().await;
-    common::seed_api_key(&pool).await;
-
-    // 2. Setup Mock Server
-    let mock_server = MockServer::start().await;
-    let gemini_base_url = mock_server.uri();
-
+    let unique_name = Uuid::new_v4().to_string();
+    let (app, mock_server, api_key) = setup_app(&unique_name).await;
     Mock::given(method("POST"))
         .and(path("/v1beta/models/gemini-pro:generateContent"))
-        .and(header("x-goog-api-key", common::VALID_API_KEY))
+        .and(header("x-goog-api-key", api_key.as_str()))
         .and(wiremock::matchers::body_json(serde_json::json!({
             "contents": [{
                 "parts": [{"text": "Hello"}]
@@ -31,38 +58,16 @@ async fn test_proxy_request_forwarding() {
         })))
         .mount(&mock_server)
         .await;
-
-    // 3. Initialize Client
-    let client = reqwest::Client::new();
-
-    // 4. Initialize App
-    let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(pool.clone()))
-            .app_data(web::Data::new(client))
-            .app_data(web::Data::new(gemini_base_url))
-            .service(
-                web::scope("/v1beta")
-                    .wrap(ApiKeyAuth)
-                    .route("/{tail:.*}", web::to(proxy::proxy_handler)),
-            ),
-    )
-    .await;
-
-    // 5. Send Request
     let req = test::TestRequest::post()
         .uri("/v1beta/models/gemini-pro:generateContent")
-        .insert_header(("x-goog-api-key", common::VALID_API_KEY))
+        .insert_header(("x-goog-api-key", api_key.as_str()))
         .set_json(serde_json::json!({
             "contents": [{
                 "parts": [{"text": "Hello"}]
             }]
         }))
         .to_request();
-
     let resp = test::call_service(&app, req).await;
-
-    // 6. Assert Response
     assert!(resp.status().is_success());
     let body: serde_json::Value = test::read_body_json(resp).await;
     assert_eq!(
@@ -73,17 +78,11 @@ async fn test_proxy_request_forwarding() {
 
 #[actix_web::test]
 async fn test_proxy_get_models() {
-    // 1. Setup Test DB and Seed Key
-    let pool = common::configure_test_db().await;
-    common::seed_api_key(&pool).await;
-
-    // 2. Setup Mock Server
-    let mock_server = MockServer::start().await;
-    let gemini_base_url = mock_server.uri();
-
+    let unique_name = Uuid::new_v4().to_string();
+    let (app, mock_server, api_key) = setup_app(&unique_name).await;
     Mock::given(method("GET"))
         .and(path("/v1beta/models"))
-        .and(header("x-goog-api-key", common::VALID_API_KEY))
+        .and(header("x-goog-api-key", api_key.as_str()))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "models": [
                 {
@@ -95,33 +94,11 @@ async fn test_proxy_get_models() {
         })))
         .mount(&mock_server)
         .await;
-
-    // 3. Initialize Client
-    let client = reqwest::Client::new();
-
-    // 4. Initialize App
-    let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(pool.clone()))
-            .app_data(web::Data::new(client))
-            .app_data(web::Data::new(gemini_base_url))
-            .service(
-                web::scope("/v1beta")
-                    .wrap(ApiKeyAuth)
-                    .route("/{tail:.*}", web::to(proxy::proxy_handler)),
-            ),
-    )
-    .await;
-
-    // 5. Send Request
     let req = test::TestRequest::get()
         .uri("/v1beta/models")
-        .insert_header(("x-goog-api-key", common::VALID_API_KEY))
+        .insert_header(("x-goog-api-key", api_key.as_str()))
         .to_request();
-
     let resp = test::call_service(&app, req).await;
-
-    // 6. Assert Response
     assert!(resp.status().is_success());
     let body: serde_json::Value = test::read_body_json(resp).await;
     assert_eq!(body["models"][0]["name"], "models/gemini-pro");

--- a/tests/streaming_test.rs
+++ b/tests/streaming_test.rs
@@ -4,7 +4,7 @@ use actix_web::{test, web, App};
 use gemini_api_proxy::{
     middleware::auth::ApiKeyAuth, models::request_log::RequestLog, routes::proxy::proxy_handler,
 };
-use sqlx::PgPool;
+use uuid::Uuid;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -12,12 +12,12 @@ mod common;
 
 #[actix_web::test]
 async fn test_streaming_usage_logging() {
-    let pool: PgPool = common::configure_test_db().await;
-    common::seed_api_key(&pool).await;
+    let pool = common::configure_test_db().await;
+    let api_key = common::seed_unique_api_key(&pool, &Uuid::new_v4().to_string()).await;
 
     // Mock the upstream Gemini API using wiremock
     let mock_server = MockServer::start().await;
-    let gemini_base_url = mock_server.uri();
+    let mock_config = common::setup_test_config(mock_server.uri());
 
     let streaming_body = "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Hello, \"}]}}]}\r\n\r\n\
              data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"world!\"}]}}]}\r\n\r\n\
@@ -38,7 +38,7 @@ async fn test_streaming_usage_logging() {
         App::new()
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(client))
-            .app_data(web::Data::new(gemini_base_url))
+            .app_data(web::Data::new(mock_config))
             .service(
                 web::scope("/v1beta")
                     .wrap(ApiKeyAuth)
@@ -49,7 +49,7 @@ async fn test_streaming_usage_logging() {
 
     let req = test::TestRequest::post()
         .uri("/v1beta/models/gemini-pro:streamGenerateContent")
-        .insert_header(("x-goog-api-key", common::VALID_API_KEY))
+        .insert_header(("x-goog-api-key", api_key.as_str()))
         .set_payload(r#"{"contents":[{"parts":[{"text":"test"}]}]}"#)
         .to_request();
 


### PR DESCRIPTION

 ## Summary
  This PR addresses the "413 Payload Too Large" error encountered when sending large requests through the proxy. It also includes critical fixes for the test suite to resolve compilation errors and database race conditions during parallel execution.

 ## Changes


###  Fix Payload Size Limit (413 Error)
   - Configurable Limits: Added PAYLOAD_SIZE_LIMIT to the application configuration (defaulting to 10MB) to allow processing of larger Gemini model prompts.
   - Server Configuration: Configured Actix-web's web::JsonConfig in main.rs to enforce the new payload limit, replacing the restrictive 32KB default.
   - Environment Support: Updated .env.example and src/config.rs to support the new configuration variable.


###  Test Suite Stability & Fixes
   - Parallel Isolation: Implemented seed_unique_api_key in tests/common/mod.rs to generate unique keys for every test. This resolves the 23505 PostgreSQL error (unique constraint violation)
     that occurred when running tests in parallel.
   - Lifetime Fixes: Resolved temporary value dropped while borrowed compilation errors in proxy_test.rs by ensuring UUID strings persist throughout the asynchronous test setup.
   - Improved Setup: Standardized setup_app helpers to return unique API keys and use shared test configurations.


###  Models & Middleware
   - API Key Names: Enhanced the api_keys table and ApiKey model with a name field to provide better context for managed keys.
   - Enhanced Logging: Added detailed logging in the ApiKeyAuth middleware to improve observability of the authentication and database lookup process.


 ### Testing
   - Verified that large payloads (up to the configured limit) are successfully accepted by the server.
   - Confirmed that cargo test passes consistently in a parallel environment.
   - Validated that database migrations correctly apply the new name field to the api_keys table.

---

Resolves #16 